### PR TITLE
adding support for handy change list of list params

### DIFF
--- a/benchmark/loader/neighbor_loader.py
+++ b/benchmark/loader/neighbor_loader.py
@@ -11,7 +11,6 @@ from torch_geometric.loader import NeighborLoader
 
 
 def run(args: argparse.ArgumentParser) -> None:
-    print(args.hetero_neighbor_sizes)
     for dataset_name in args.datasets:
         print(f"Dataset: {dataset_name}")
         root = osp.join(args.root, dataset_name)

--- a/benchmark/loader/neighbor_loader.py
+++ b/benchmark/loader/neighbor_loader.py
@@ -3,6 +3,7 @@ import os.path as osp
 from timeit import default_timer
 
 import tqdm
+import ast
 from ogb.nodeproppred import PygNodePropPredDataset
 
 import torch_geometric.transforms as T
@@ -88,9 +89,9 @@ if __name__ == '__main__':
     add('--eval-batch-sizes', default=[16384, 8192, 4096, 2048, 1024, 512],
         type=int, nargs='+')
     add('--homo-neighbor_sizes', default=[[10, 5], [15, 10, 5], [20, 15, 10]],
-        type=int, nargs='+')
-    add('--hetero-neighbor_sizes', default=[[5], [10], [10, 5]], type=int,
-        nargs='+')
+        type=ast.literal_eval)
+    add('--hetero-neighbor_sizes', default=[[5], [10], [10, 5]],
+        type=ast.literal_eval)
     add('--num-workers', default=0)
     add('--runs', default=3)
 

--- a/benchmark/loader/neighbor_loader.py
+++ b/benchmark/loader/neighbor_loader.py
@@ -11,6 +11,7 @@ from torch_geometric.loader import NeighborLoader
 
 
 def run(args: argparse.ArgumentParser) -> None:
+    print(args.hetero_neighbor_sizes)
     for dataset_name in args.datasets:
         print(f"Dataset: {dataset_name}")
         root = osp.join(args.root, dataset_name)
@@ -83,10 +84,14 @@ if __name__ == '__main__':
     add('--device', default='cpu')
     add('--datasets', nargs="+", default=['arxiv', 'products', 'mag'])
     add('--root', default='../../data')
-    add('--batch-sizes', default=[8192, 4096, 2048, 1024, 512])
-    add('--eval-batch-sizes', default=[16384, 8192, 4096, 2048, 1024, 512])
-    add('--homo-neighbor_sizes', default=[[10, 5], [15, 10, 5], [20, 15, 10]])
-    add('--hetero-neighbor_sizes', default=[[5], [10], [10, 5]], type=int)
+    add('--batch-sizes', default=[8192, 4096, 2048, 1024, 512], type=int,
+        nargs='+')
+    add('--eval-batch-sizes', default=[16384, 8192, 4096, 2048, 1024, 512],
+        type=int, nargs='+')
+    add('--homo-neighbor_sizes', default=[[10, 5], [15, 10, 5], [20, 15, 10]],
+        type=int, nargs='+')
+    add('--hetero-neighbor_sizes', default=[[5], [10], [10, 5]], type=int,
+        nargs='+')
     add('--num-workers', default=0)
     add('--runs', default=3)
 


### PR DESCRIPTION
usage example:
python neighbor_loader.py --hetero-neighbor_sizes [[1],[1,2]] --homo-neighbor_sizes [[3],[1,2]]

constrains: you cannot use the nargs with that(?)